### PR TITLE
fix: 修复 HTTP 认证 URL 拼接缺少 baseurl，pip 安装增加 --ignore-installed

### DIFF
--- a/shell/update/git.sh
+++ b/shell/update/git.sh
@@ -45,7 +45,7 @@ function git_clone_with_http_auth() {
     if [[ "${url}" == http*://* ]] && [[ "${url}" != http*://*:*@* ]]; then
         local protocol=$(echo $url | awk -F/ '{print $1}')
         local baseurl=$(echo $url | awk -F/ '{print $3}')
-        url="${protocol}//${username}:${password}@${url#"$protocol"//"$baseurl"}"
+        url="${protocol}//${username}:${password}@${baseurl}${url#"$protocol"//"$baseurl"}"
     fi
 
     git_clone "${url}" "${dir}" "${branch}" "${text}"
@@ -109,7 +109,7 @@ function reset_romote_url_with_http_auth() {
     if [[ "${url}" == http*://* ]] && [[ "${url}" != http*://*:*@* ]]; then
         local protocol=$(echo $url | awk -F/ '{print $1}')
         local baseurl=$(echo $url | awk -F/ '{print $3}')
-        url="${protocol}//${username}:${password}@${url#"$protocol"//"$baseurl"}"
+        url="${protocol}//${username}:${password}@${baseurl}${url#"$protocol"//"$baseurl"}"
     fi
 
     reset_romote_url "${work_dir}" "${url}"

--- a/shell/utils/dep.sh
+++ b/shell/utils/dep.sh
@@ -379,7 +379,7 @@ function pip_dep_install() {
         echo "[dep.sh] ERROR: pip3 is not installed" >&2
         return 1
     }
-    pip3 install --no-cache-dir --break-system-packages "${pkg}"
+    pip3 install --no-cache-dir --break-system-packages --ignore-installed "${pkg}"
 }
 
 function pip_dep_uninstall() {


### PR DESCRIPTION
### 修改内容

#### 1. `shell/update/git.sh` — 修复 HTTP 认证仓库地址重定向丢失 baseurl

原代码在拼接认证 URL 时丢失了 `${baseurl}`，导致重定向后的地址不完整。

```diff
- url="${protocol}//${username}:${password}@${url#"$protocol"//"$baseurl"}"
+ url="${protocol}//${username}:${password}@${baseurl}${url#"$protocol"//"$baseurl"}"
```

两处均有修复：`git_clone_with_http_auth` 和 `reset_romote_url_with_http_auth`。

#### 2. `shell/utils/dep.sh` — pip3 install 增加 `--ignore-installed`

避免因系统已安装包版本冲突导致安装失败。

### 测试
已在实际环境中验证通过，更新同步功能正常。